### PR TITLE
Migrated to AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:27.1.0'
+    api 'androidx.appcompat:appcompat:1.1.0-alpha01'
 }

--- a/android/src/main/java/com/ly/wifi/WifiDelegate.java
+++ b/android/src/main/java/com/ly/wifi/WifiDelegate.java
@@ -10,8 +10,7 @@ import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
-import android.support.v4.app.ActivityCompat;
-import android.util.Log;
+import androidx.core.app.ActivityCompat;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,10 +35,10 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.ly.wifiexample"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -56,6 +56,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
 }


### PR DESCRIPTION
The Flutter community is in the process of adopting [AndroidX](https://developer.android.com/jetpack/androidx/) - a replacement of Android Support Libraries. One of the reasons for the move is the problem of co-existing different versions of Support Libraries. The [move to AndroidX](https://github.com/flutter/flutter/issues/23995) has accelerated recently by the release of Flutter 1.1.8, which [broke a lot of plugins](https://github.com/flutter/flutter/wiki/Postmortem:-AndroidX-plugin-migration) that do not support AndroidX. Flutter-wifi is one of the plugins that are broken when using AndroidX. This pull request is to migrate Flutter-wifi to AndroidX. 

I performed the migration using the [automatic Refactoring method](https://developer.android.com/jetpack/androidx/migrate). I tested my changes by running the example project. 

Please note that this change updates compiledSDKVersion from 27 to 28, which is now the default `compileSdkVersion` for Flutter, as AndroidX requires version 28. Because this is is a breaking change, it may justify a bump of the major release version as is done by other plugins. 