### PR TITLE
Add BSSID to WifiResult

### DIFF
--- a/android/src/main/java/com/ly/wifi/WifiDelegate.java
+++ b/android/src/main/java/com/ly/wifi/WifiDelegate.java
@@ -193,16 +193,10 @@ WifiDelegate implements PluginRegistry.RequestPermissionsResultListener {
                     level = 0;
                 }
                 HashMap<String, Object> maps = new HashMap<>();
-                if (key.isEmpty()) {
+                if (key.isEmpty() || scanResult.SSID.contains(key)) {
                     maps.put("ssid", scanResult.SSID);
                     maps.put("level", level);
                     list.add(maps);
-                } else {
-                    if (scanResult.SSID.contains(key)) {
-                        maps.put("ssid", scanResult.SSID);
-                        maps.put("level", level);
-                        list.add(maps);
-                    }
                 }
             }
         }

--- a/android/src/main/java/com/ly/wifi/WifiDelegate.java
+++ b/android/src/main/java/com/ly/wifi/WifiDelegate.java
@@ -196,6 +196,7 @@ WifiDelegate implements PluginRegistry.RequestPermissionsResultListener {
                 if (key.isEmpty() || scanResult.SSID.contains(key)) {
                     maps.put("ssid", scanResult.SSID);
                     maps.put("level", level);
+                    maps.put("bssid", scanResult.BSSID);
                     list.add(maps);
                 }
             }

--- a/android/src/main/java/com/ly/wifi/WifiDelegate.java
+++ b/android/src/main/java/com/ly/wifi/WifiDelegate.java
@@ -260,11 +260,15 @@ WifiDelegate implements PluginRegistry.RequestPermissionsResultListener {
         if (tempConfig != null) {
             wifiManager.removeNetwork(tempConfig.networkId);
         }
-        config.preSharedKey = "\"" + Password + "\"";
+        if (Password != null && !Password.isEmpty()) {
+            config.preSharedKey = "\"" + Password + "\"";
+            config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
+        } else {
+            config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
+        }
         config.hiddenSSID = true;
         config.allowedAuthAlgorithms.set(WifiConfiguration.AuthAlgorithm.OPEN);
         config.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.TKIP);
-        config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
         config.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
         config.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.CCMP);
         config.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);

--- a/ios/Classes/WifiPlugin.m
+++ b/ios/Classes/WifiPlugin.m
@@ -40,7 +40,12 @@
             NSDictionary* argsMap = call.arguments;
             NSString *ssid = argsMap[@"ssid"];
             NSString *password = argsMap[@"password"];
-            NEHotspotConfiguration * hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:password isWEP:NO];
+            NEHotspotConfiguration *hotspotConfig;
+            if ([password length] == 0) {
+                hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
+            } else {
+                hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:password isWEP:NO];
+            }
             [[NEHotspotConfigurationManager sharedManager] applyConfiguration:hotspotConfig completionHandler:^(NSError * _Nullable error) {
                 if(error == nil){
                     result(@1);

--- a/lib/wifi.dart
+++ b/lib/wifi.dart
@@ -31,11 +31,13 @@ class Wifi {
     return resultList;
   }
 
-  static Future<WifiState> connection(String ssid, String password) async {
+  static Future<WifiState> connection(String ssid, [String password]) async {
     final Map<String, dynamic> params = {
-      'ssid': ssid,
-      'password': password,
+      'ssid': ssid
     };
+    if (password != null && password.isNotEmpty) {
+      params.addEntries([MapEntry('password', password)]);
+    }
     int state = await _channel.invokeMethod('connection', params);
     switch (state) {
       case 0:

--- a/lib/wifi.dart
+++ b/lib/wifi.dart
@@ -26,7 +26,7 @@ class Wifi {
     var results = await _channel.invokeMethod('list', params);
     List<WifiResult> resultList = [];
     for (int i = 0; i < results.length; i++) {
-      resultList.add(WifiResult(results[i]['ssid'], results[i]['level']));
+      resultList.add(WifiResult(results[i]['ssid'], results[i]['level'], results[i]['bssid']));
     }
     return resultList;
   }
@@ -55,6 +55,7 @@ class Wifi {
 class WifiResult {
   String ssid;
   int level;
+  String bssid;
 
-  WifiResult(this.ssid, this.level);
+  WifiResult(this.ssid, this.level, this.bssid);
 }


### PR DESCRIPTION
Adding BSSID is useful when multiple APs share the same SSID and you need to distinguish them.