### PR TITLE
Add support for open Wi-Fi networks

### DIFF
--- a/android/src/main/java/com/ly/wifi/WifiDelegate.java
+++ b/android/src/main/java/com/ly/wifi/WifiDelegate.java
@@ -260,11 +260,15 @@ WifiDelegate implements PluginRegistry.RequestPermissionsResultListener {
         if (tempConfig != null) {
             wifiManager.removeNetwork(tempConfig.networkId);
         }
-        config.preSharedKey = "\"" + Password + "\"";
+        if (Password != null && !Password.isEmpty()) {
+            config.preSharedKey = "\"" + Password + "\"";
+            config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
+        } else {
+            config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
+        }
         config.hiddenSSID = true;
         config.allowedAuthAlgorithms.set(WifiConfiguration.AuthAlgorithm.OPEN);
         config.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.TKIP);
-        config.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
         config.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
         config.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.CCMP);
         config.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);

--- a/ios/Classes/WifiPlugin.m
+++ b/ios/Classes/WifiPlugin.m
@@ -40,7 +40,12 @@
             NSDictionary* argsMap = call.arguments;
             NSString *ssid = argsMap[@"ssid"];
             NSString *password = argsMap[@"password"];
-            NEHotspotConfiguration * hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:password isWEP:NO];
+            NEHotspotConfiguration *hotspotConfig;
+            if ([password length] == 0) {
+                hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
+            } else {
+                hotspotConfig = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:password isWEP:NO];
+            }
             [[NEHotspotConfigurationManager sharedManager] applyConfiguration:hotspotConfig completionHandler:^(NSError * _Nullable error) {
                 if(error == nil){
                     result(@1);

--- a/lib/wifi.dart
+++ b/lib/wifi.dart
@@ -31,11 +31,13 @@ class Wifi {
     return resultList;
   }
 
-  static Future<WifiState> connection(String ssid, String password) async {
+  static Future<WifiState> connection(String ssid, [String password]) async {
     final Map<String, dynamic> params = {
-      'ssid': ssid,
-      'password': password,
+      'ssid': ssid
     };
+    if (password != null && password.isNotEmpty) {
+      params.addEntries([MapEntry('password', password)]);
+    }
     int state = await _channel.invokeMethod('connection', params);
     switch (state) {
       case 0:


### PR DESCRIPTION
You just need to leave out the password field when calling the "connection" method.
Also makes password an optional positional parameter to ensure compatibility with
previous code.

Compiled and tested working on Android.
Compiled on iOS but need testing, should work as far as I know from official Apple documentation.